### PR TITLE
Make serialization recursion tracking threadsafe ... I think

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 A Python library to make creation of CIDOC CRM easier by mapping classes/predicates to python objects/properties, thereby making the CRM "CRoMulent", a Simpsons neologism for "acceptable" or "fine".  
 
-## Status: Alpha
+## Status: Beta
 
-The core vocabulary loading functionality is reasonably stable. The vocabulary section is expanding as we find new, useful terms to include and will likely change to instead be loaded separately from configurations.
+The core vocabulary loading functionality is reasonably stable. The vocabulary section is expanding as we find new, useful terms to include and will likely constantly change.
 
 The code is actively being developed and compability breaking changes are thus to be expected as we use it in various projects across The J Paul Getty Trust, and beyond.
 
@@ -76,7 +76,6 @@ Internal:
 * `debug_level` Settings for debugging errors and warnings, defaults to "warn"
 * `log_stream` An object implementing the stream API to write log messages to, defaults to sys.stderr
 
-Note that factories are NOT thread safe during serialization. A property on the factory is used to maintain which objects have been serialized already, to avoid infinite recursion in a cyclic graph. Create a new factory object per thread if necessary.
 
 
 ## How it Works

--- a/cromulent/model.py
+++ b/cromulent/model.py
@@ -222,7 +222,7 @@ class CromulentFactory(object):
 
 		return self.base_url + what.__class__._uri_segment + "/" + str(slug)		
 
-	def toJSON(self, what, done={}):
+	def toJSON(self, what, done=None):
 		""" Serialize what, making sure of no infinite loops """
 		if not done:
 			done = {}
@@ -281,14 +281,14 @@ class CromulentFactory(object):
 			out = self.collapse_json(out, collapse)
 		return out 		
 
-	def toString(self, what, compact=True, collapse=0, done={}):
+	def toString(self, what, compact=True, collapse=0, done=None):
 		"""Return JSON setialization as string."""
 		if not done:
 			done = {}
 		js = self.toJSON(what, done=done)
 		return self._buildString(js, compact, collapse)
 
-	def toFile(self, what, compact=True, filename="", done={}):
+	def toFile(self, what, compact=True, filename="", done=None):
 		"""Write to local file.
 
 		Creates directories as necessary
@@ -371,7 +371,7 @@ class ExternalResource(object):
 		else:
 			self.id = ""
 
-	def _toJSON(self, top=False, done={}):
+	def _toJSON(self, done, top=False):
 		if self._factory.elasticsearch_compatible:
 			return {'id': self.id}
 		else:

--- a/cromulent/model.py
+++ b/cromulent/model.py
@@ -371,7 +371,7 @@ class ExternalResource(object):
 		else:
 			self.id = ""
 
-	def _toJSON(self, top=False):
+	def _toJSON(self, top=False, done={}):
 		if self._factory.elasticsearch_compatible:
 			return {'id': self.id}
 		else:
@@ -588,7 +588,7 @@ class BaseResource(ExternalResource):
 			if type(current) != list and multiple and self._factory.process_multiplicity:
 				object.__setattr__(self, which, [getattr(self, which)])
 
-	def _toJSON(self, top=False, done={}):
+	def _toJSON(self, done, top=False):
 		"""Serialize as JSON."""
 		# If we're already in the graph, return our URI only
 		# This should only be called from the factory!

--- a/cromulent/vocab.py
+++ b/cromulent/vocab.py
@@ -377,24 +377,6 @@ def add_art_setter():
 		super(InformationObject, self)._post_init(**kw)
 	InformationObject._post_init = art2_post_init
 
-# def add_proxy_wrapper():
-# 	# There isn't an inverse of proxyFor / proxyIn.
-# 	# So we need to use a JSON-LD @reverse property `proxies`
-# 	# This adds it, as it's not part of the ontology proper.
-
-# 	Aggregation.proxies = []
-# 	def aggr_post_init(self, **kw):
-# 		self.proxies = []
-# 	Aggregation._post_init = aggr_post_init
-
-# 	def proxy_set_magic_resource(self, which, value, inversed=False):
-# 		super(Proxy, self)._set_magic_resource(which, value, inversed)
-# 		# Look up what the context maps ore:proxyIn to
-# 		pin = factory.context_rev.get('ore:proxyIn', 'proxyIn')
-# 		if which == 'proxyIn':
-# 			value.proxies.append(self)
-# 	Proxy._set_magic_resource = proxy_set_magic_resource
-
 def add_attribute_assignment_check():
 	# Allow references to properties in p2 on AttrAssign
 	# Validate that the property is allowed in assigned

--- a/cromulent/vocab.py
+++ b/cromulent/vocab.py
@@ -79,6 +79,7 @@ ext_classes = {
 	"FoliationStatement": {"parent": LinguisticObject, "id":"300200662", "label": "Foliation Statement", "brief": True},
 	"Abstract": {"parent": LinguisticObject, "id":"300026032", "label": "Abstract", "brief": True},
 	"Note": {"parent": LinguisticObject, "id":"300027200", "label": "Note", "brief": True},
+	"Annotation": {"parent": LinguisticObject, "id":"300026100", "label":"Annotation"},
 
 	"CatalogueRaisonne": {"parent": LinguisticObject, "id":"300026061", "label": "Catalogue Raisonne"},
 	"AuctionCatalog": {"parent": LinguisticObject, "id":"300026068", "label": "Auction Catalog"},
@@ -376,23 +377,23 @@ def add_art_setter():
 		super(InformationObject, self)._post_init(**kw)
 	InformationObject._post_init = art2_post_init
 
-def add_proxy_wrapper():
-	# There isn't an inverse of proxyFor / proxyIn.
-	# So we need to use a JSON-LD @reverse property `proxies`
-	# This adds it, as it's not part of the ontology proper.
+# def add_proxy_wrapper():
+# 	# There isn't an inverse of proxyFor / proxyIn.
+# 	# So we need to use a JSON-LD @reverse property `proxies`
+# 	# This adds it, as it's not part of the ontology proper.
 
-	Aggregation.proxies = []
-	def aggr_post_init(self, **kw):
-		self.proxies = []
-	Aggregation._post_init = aggr_post_init
+# 	Aggregation.proxies = []
+# 	def aggr_post_init(self, **kw):
+# 		self.proxies = []
+# 	Aggregation._post_init = aggr_post_init
 
-	def proxy_set_magic_resource(self, which, value, inversed=False):
-		super(Proxy, self)._set_magic_resource(which, value, inversed)
-		# Look up what the context maps ore:proxyIn to
-		pin = factory.context_rev.get('ore:proxyIn', 'proxyIn')
-		if which == 'proxyIn':
-			value.proxies.append(self)
-	Proxy._set_magic_resource = proxy_set_magic_resource
+# 	def proxy_set_magic_resource(self, which, value, inversed=False):
+# 		super(Proxy, self)._set_magic_resource(which, value, inversed)
+# 		# Look up what the context maps ore:proxyIn to
+# 		pin = factory.context_rev.get('ore:proxyIn', 'proxyIn')
+# 		if which == 'proxyIn':
+# 			value.proxies.append(self)
+# 	Proxy._set_magic_resource = proxy_set_magic_resource
 
 def add_attribute_assignment_check():
 	# Allow references to properties in p2 on AttrAssign

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -157,6 +157,14 @@ class TestFactorySerialization(unittest.TestCase):
 		# testing unicode in 2, str in 3 :(
 		self.assertTrue(type(js) != dict)		
 
+	def test_recursion(self):
+		x = model.Activity()
+		x.part = x
+		js = model.factory.toJSON(x)
+		# If our recursion checks have regressed, this will barf right here
+		self.assertTrue(1)
+
+
 class TestProcessTSV(unittest.TestCase):
 
 	def test_process_tsv(self):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -150,10 +150,10 @@ class TestFactorySerialization(unittest.TestCase):
 	def test_external(self):
 		x = model.ExternalResource(ident="1")
 		model.factory.elasticsearch_compatible = 1
-		js = x._toJSON()
+		js = x._toJSON(done=None)
 		self.assertTrue(type(js) == dict)
 		model.factory.elasticsearch_compatible = 0
-		js = x._toJSON()
+		js = x._toJSON(done=None)
 		# testing unicode in 2, str in 3 :(
 		self.assertTrue(type(js) != dict)		
 

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -26,11 +26,11 @@ class TestClassBuilder(unittest.TestCase):
 	def test_art_setter(self):
 		p = model.ManMadeObject("a", art=1)
 		p._label = "a"
-		pj = p._toJSON()
+		pj = p._toJSON(done={})
 		self.assertFalse(pj.get('classified_as', None))
 		vocab.add_art_setter()
 		p2 = vocab.Painting("b", art=1)
-		p2j = p2._toJSON()
+		p2j = p2._toJSON(done={})
 		# self.assertTrue("aat:300133025" in p2j['classified_as'])
 		# no idea why the aat:1234 pattern doesn't work here
 		# something to do with failing to set up the factory?


### PR DESCRIPTION

PR takes done off of factory as a property, and passes it around by reference.  Functions that are called as the API need to set it explicitly to a new empty dict, otherwise the VM seems to use the same dict as the previous invocation if it defaults to the param default. (Who knew? Certainly not me)



