### PR TITLE
Implement requested functionality

### DIFF
--- a/cromulent/model.py
+++ b/cromulent/model.py
@@ -11,7 +11,6 @@ import datetime
 
 KEY_ORDER_DEFAULT = 10000
 LINKED_ART_CONTEXT_URI = "https://linked.art/ns/v1/linked-art.json"
-CRM_EXT_CONTEXT_URI = "https://linked.art/ns/v1/cidoc-extension.json"
 
 try:
     import json
@@ -97,11 +96,10 @@ class CromulentFactory(object):
 		self.context_rev = {}
 		# Maybe load it up for prefixes
 		if load_context:
+			# Leave this as a map for future extensions
 			context_filemap = {
 				LINKED_ART_CONTEXT_URI: 
-					os.path.join(os.path.dirname(__file__), 'data', 'linked-art.json'),
-				CRM_EXT_CONTEXT_URI:
-					os.path.join(os.path.dirname(__file__), 'data', 'cidoc-extension.json')
+					os.path.join(os.path.dirname(__file__), 'data', 'linked-art.json')
 			}
 			context_filemap.update(context_file)
 			self.load_context(context, context_filemap)

--- a/cromulent/model.py
+++ b/cromulent/model.py
@@ -430,7 +430,7 @@ class BaseResource(ExternalResource):
 
 	@type.setter
 	def type(self, value):
-		raise RequirementError("Must not set 'type' on resources directly")
+		raise AttributeError("Must not set 'type' on resources directly")
 
 
 	def _post_init(self, **kw):
@@ -490,7 +490,7 @@ class BaseResource(ExternalResource):
 					rng = c._properties[which]['range']
 					if rng == str:					
 						return 1
-					elif type(value) == BaseResource:
+					elif type(value) is BaseResource:
 						# Allow direct instances of base resource anywhere
 						# this is an override for external URIs
 						return 2
@@ -584,7 +584,7 @@ class BaseResource(ExternalResource):
 			current = None
 		if not current:
 			object.__setattr__(self, which, value)
-		elif type(current) == list:
+		elif type(current) is list:
 			current.append(value)
 		else:
 			value = [current, value]
@@ -645,7 +645,7 @@ class BaseResource(ExternalResource):
 					self.maybe_warn(msg)
 
 		# Add back context at the top, if set
-		if top == self and self._factory.context_uri: 
+		if top is self and self._factory.context_uri: 
 			d['@context'] = self._factory.context_uri
 
 		if (self._factory.id_type_label and self.id in done) or (top is not self and not self._embed):
@@ -685,7 +685,7 @@ class BaseResource(ExternalResource):
 						done[v.id] = 1
 					else:
 						tbd.append(v.id)
-				elif type(v) == list:
+				elif type(v) is list:
 					for ni in v:
 						if isinstance(ni, ExternalResource):
 							if self._factory.linked_art_boundaries and \
@@ -709,7 +709,7 @@ class BaseResource(ExternalResource):
 					if done[v.id] == self.id:
 						del done[v.id]
 					d[k] = v._toJSON(done=done, top=top)
-				elif type(v) == list:
+				elif type(v) is list:
 					newl = []
 					for ni in v:
 						if isinstance(ni, ExternalResource):

--- a/cromulent/model.py
+++ b/cromulent/model.py
@@ -12,23 +12,10 @@ import datetime
 KEY_ORDER_DEFAULT = 10000
 LINKED_ART_CONTEXT_URI = "https://linked.art/ns/v1/linked-art.json"
 
-try:
-    import json
-except:
-    # Fallback for 2.5
-    import simplejson as json
 
-try:
-    # Only available in 2.7+
-    # This makes the code a bit messy, but eliminates the need
-    # for the locally hacked ordered json encoder
-    from collections import OrderedDict
-except:
-    # Backported...
-    try:
-        from ordereddict import OrderedDict
-    except:
-        raise Exception("To run with old pythons you must: easy_install ordereddict")
+# 2.5 and 2.6 are very out of date. Assume 2.7 or better
+import json
+from collections import OrderedDict
 
 try:
 	STR_TYPES = [str, unicode] #Py2

--- a/cromulent/model.py
+++ b/cromulent/model.py
@@ -401,12 +401,11 @@ class BaseResource(ExternalResource):
 			elif self._okayToUse == 2:
 				self.maybe_warn("Class '%s' is configured to warn on use" % self.__class__._type)
 
-		# Set info other than identifier
-		# self.type = self.__class__._type
+		# Set label and value/content
 		if label:
 			self._label = label
 		# this might raise an exception if value is not allowed on the object
-		# but easier to do it in the main init than on generated subclasses
+		# but easier to do it in the main init than on many generated subclasses
 		if value:
 			try:
 				self.value = value

--- a/cromulent/model.py
+++ b/cromulent/model.py
@@ -73,8 +73,8 @@ class CromulentFactory(object):
 
 		self.auto_id_type = "int-per-segment" #  "int", "int-per-type", "int-per-segment", "uuid"
 		self.default_lang = lang
-		self.filename_extension = ".json"
-		# context_uri might actually be a list of URIs, and/or dicts
+		self.filename_extension = ".json"  # some people like .jsonld
+		# N.B. context_uri might actually be a list of URIs, and/or dicts
 		self.context_uri = context
 		self.context_json = {}
 

--- a/cromulent/multiple_instantiation.py
+++ b/cromulent/multiple_instantiation.py
@@ -11,7 +11,10 @@ from cromulent.model import Destruction, EndOfExistence, Activity, Appellation, 
 class DestructionActivity(Destruction, Activity):
 	_uri_segment = "Activity"
 	_type = ["crm:E6_Destruction", "crm:E7_Activity"]
-	_niceType = ["Destruction", "Activity"]
+
+	@property
+	def type(self):
+		return ["Destruction", "Activity"]
 DestructionActivity._classhier = inspect.getmro(DestructionActivity)[:-1]
 
 # And hence we make an EndOfExistence+Activity class
@@ -20,11 +23,11 @@ class EoEActivity(EndOfExistence, Activity):
 	_uri_segment = "Activity"
 	_type = ["crm:64_End_of_Existence", "crm:E7_Activity"]
 	_niceType = ["EndOfExistence", "Activity"]	
+
+	@property
+	def type(self):
+		return ["EndOfExistence", "Activity"]
+
 EoEActivity._classhier = inspect.getmro(EoEActivity)[:-1]
 
-# And a LinguisticAppellation
-class LinguisticAppellation(Appellation, LinguisticObject):
-	_uri_segment = "Appellation"
-	_type = ["crm:E41_Appellation", "crm:E33_Linguistic_Object"]
-	_niceType  = ["Appellation", "LinguisticObject"]
-LinguisticAppellation._classhier = inspect.getmro(LinguisticAppellation)[:-1]
+# No need for Linguistic Appellation any more, as we have E33_E41_Linguistic_Appellation

--- a/cromulent/vocab.py
+++ b/cromulent/vocab.py
@@ -432,31 +432,31 @@ def add_attribute_assignment_check():
 
 def add_linked_art_boundary_check():
 
-	boundary_classes = [Actor, ManMadeObject, Person, Group, VisualItem, \
-		Place, Acquisition, Period, LinguisticObject, Phase, Set]
-	embed_classes = [Type, Name, Identifier, Dimension, Birth, Creation, \
+	boundary_classes = [x.__name__ for x in [Actor, ManMadeObject, Person, Group, VisualItem, \
+		Place, Acquisition, Period, LinguisticObject, Phase, Set]]
+	embed_classes = [x.__name__ for x in [Type, Name, Identifier, Dimension, Birth, Creation, \
 		Currency, Death, Destruction, Dissolution, Formation, Language, \
-		Material, MeasurementUnit, \
-		MonetaryAmount, Payment, Production, TimeSpan]
+		Material, MeasurementUnit, MonetaryAmount, Payment, Production, TimeSpan]]
 
 	# Activity, AttributeAssignment, InformationObject, TransferOfCustody, Move
+	# Propositional Object
 
 	def my_linked_art_boundary_check(self, top, rel, value):
-		if isinstance(value, LinguisticObject) and instances['brief text'] in value.classified_as:
+		if isinstance(value, LinguisticObject) and hasattr(value, 'classified_as') and instances['brief text'] in value.classified_as:
 			# linguistic objects and * can be described by embedded linguistic objects
 			return True
-		elif type(value) == type(self) and rel in ["part", "member"]:
-			# Internal simple partition
+		elif rel in ["part", "member"]:
+			# Downwards, internal simple partitioning 
 			return True
 		elif rel in ["part_of", 'member_of']:
 			# upwards partition refs are inclusion, and always boundary crossing
 			return False
-		elif type(value) in boundary_classes:
+		elif value.type in boundary_classes:
 			return False
-		elif type(value) in embed_classes:
+		elif value.type in embed_classes:
 			return True
 		else:
-			print("Falling through to default of embed for class %s" % type(self))
+			# Default to embedding to avoid data loss
 			return True
 
 	setattr(BaseResource, "_linked_art_boundary_okay", my_linked_art_boundary_check)

--- a/cromulent/vocab.py
+++ b/cromulent/vocab.py
@@ -138,8 +138,8 @@ ext_classes = {
 	"Auctioneer":  {"parent": Person, "id":"300025208", "label": "Auctioneer"}, # is this useful?
 
 
-	"AuctionEvent": {"parent": Activity, "id":"300xxxxxx", "label": "Auction Event"},
-	"Auction":     {"parent": Activity, "id":"300054751", "label": "Auction of Lot"}, # Individual auction-of-lot
+	"AuctionEvent": {"parent": Activity, "id":"300054751", "label": "Auction Event"},
+	"Auction":     {"parent": Activity, "id":"300420001", "label": "Auction of Lot"}, # Individual auction-of-lot
 	"Bidding":     {"parent": Creation, "id":"300054602", "label": "Bidding"}, # individual bid
 	"Curating":    {"parent": Activity, "id":"300054277", "label": "Curating"},
 	"Inventorying": {"parent": Activity, "id":"300077506", "label": "Inventorying"},

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         'data/cidoc-extension.json', 'data/crm-profile.json']
     },
     test_suite="tests",
-    version = '0.11.7',
+    version = '0.11.9',
     description = 'A library for mapping CIDOC-CRM classes to Python objects',
     author = 'Rob Sanderson',
     author_email = 'rsanderson@getty.edu',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         'data/cidoc-extension.json', 'data/crm-profile.json']
     },
     test_suite="tests",
-    version = '0.11.9',
+    version = '0.12.0',
     description = 'A library for mapping CIDOC-CRM classes to Python objects',
     author = 'Rob Sanderson',
     author_email = 'rsanderson@getty.edu',

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -262,7 +262,8 @@ class TestBaseResource(unittest.TestCase):
 
 	def test_init(self):
 		self.assertEqual(self.artist.id, 'http://lod.example.org/museum/Person/00001')
-		self.assertEqual(self.artist.type, 'crm:E21_Person')
+		self.assertEqual(self.artist._type, 'crm:E21_Person')
+		self.assertEqual(self.artist.type, 'Person')
 		self.assertEqual(self.artist._label, 'Jane Doe')
 		self.assertFalse(hasattr(self.artist, 'value'))
 		self.assertFalse(hasattr(self.artist, 'has_type'))

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -34,3 +34,19 @@ class TestClassBuilder(unittest.TestCase):
 		# self.assertTrue("aat:300133025" in p2j['classified_as'])
 		# no idea why the aat:1234 pattern doesn't work here
 		# something to do with failing to set up the factory?
+
+	def test_boundary_setter(self):
+		vocab.add_linked_art_boundary_check()
+		p = model.Person()
+		p2 = model.Person()
+		n = model.Name()
+		n.content = "Test"
+		p2.identified_by = n
+		p.related = p2
+		# Now, Test should not appear in the resulting JSON of p
+		factory.linked_art_boundaries = True
+		js = factory.toJSON(p)
+		self.assertTrue(not 'identified_by' in js['related'][0])
+		factory.linked_art_boundaries = False
+		js = factory.toJSON(p)
+		self.assertTrue('identified_by' in js['related'][0])		


### PR DESCRIPTION

* Make dir(object) work, such that it reports the magic properties
* Refactor handling of `type` to make object.type (getter) work, and raise for setter
* Refactor `top` handling to allow it to be passed through for determining graph boundary (currently not used, but pretty sure it's needed)
* Implement algorithmic graph boundary test in vocab to keep linked art profile separable from core code, and graph separate from API
* Make `content` an alias for `value` in constructor
* Make use of new `type` magic to fix multiple_instantiation classes (not used in current profile), and simplify resulting `type` serialization
