### PR TITLE
Make Set subclass of Proposition and Legal

### DIFF
--- a/cromulent/data/crm_vocab.tsv
+++ b/cromulent/data/crm_vocab.tsv
@@ -390,7 +390,7 @@ P90b_has_upper_value_limit	property	upper_value_limit	has upper value limit	This
 la:Payment	class	Payment	Payment	Payment of Money	E7_Activity	1
 la:PropertyInterest	class	PropertyInterest	Property Interest	A particular property interest, be it ownership or security, of intellectual or physical property	E71_Human-Made_Thing	1
 la:Phase	class	Phase	Phase	The period of time during which an entity is in a certain phase or state of its existence.  The phase can be physical (the box is open, the painting is 14 ft wide) or social (the sculpture is owned by some Actor, the building is used as a castle).	E4_Period	1
-la:Set	class	Set	Set		E28_Conceptual_Object	1
+la:Set	class	Set	Set		E89_Propositional_Object|E72_Legal_Object	1
 la:Relationship	class	Relationship	Relationship		E28_Conceptual_Object	1
 la:paid_amount	property	paid_amount	Paid Amount	The amount paid.		la:Payment	E97_Monetary_Amount		10000	1	0
 la:paid_from	property	paid_from	Paid From	Who the payment came from		la:Payment	E39_Actor		10000	1	1

--- a/utils/data/linkedart.xml
+++ b/utils/data/linkedart.xml
@@ -163,11 +163,13 @@
 
 <!-- Set of Things, as potential superclass of Group and Collection -->
 <!-- e.g. an auction lot is not a curated holding, but we need a class for its membership -->
+<!-- Sets can have rights (right to add /remove) and be about subjects (e.g. exhibition) -->
 
 <rdfs:Class rdf:about="https://linked.art/ns/terms/Set">
     <rdfs:label xml:lang="en">Set</rdfs:label>
     <rdfs:comment></rdfs:comment>
-    <rdfs:subClassOf rdf:resource="E28_Conceptual_Object"/>
+    <rdfs:subClassOf rdf:resource="E89_Propositional_Object"/>
+    <rdfs:subClassOf rdf:resource="E72_Legal_Object"/>
 </rdfs:Class>
 
 <rdf:Property rdf:about="https://linked.art/ns/terms/has_member">


### PR DESCRIPTION

Sets should be able to have rights associated with them - for example I do not have the right to add an item into the collection of the museum, nor to add a concept to the set of terms in AAT. Ed Ruscha and the GRI, conversely, have the right to add objects into the Ruscha archive. This means it needs to be a Legal Object.

Similarly, the Ruscha archive or a set of objects as an exhibition, can be "about" some set of topics.  This means it needs to be a Propositional Object.

The merge point of these is Information Object, but the set is not Symbolic in nature. Thus two super-classes, as above.