### PR TITLE
Split embed classes to types, add multiple_instances_per_property

### DIFF
--- a/cromulent/model.py
+++ b/cromulent/model.py
@@ -748,13 +748,13 @@ change factory.multiple_instances_per_property to 'drop' or 'allow'""")
 					d[k] = v._toJSON(done=done, top=top)
 				elif type(v) is list:
 					newl = []
-					uniq = []
+					uniq = set()
 					for ni in v:
 						if self._factory.multiple_instances_per_property == "drop":
 							if id(ni) in uniq:
 								continue
 							else:
-								uniq.append(id(ni))
+								uniq.add(id(ni))
 						if isinstance(ni, ExternalResource):
 							if done[id(ni)] == id(self):
 								del done[id(ni)]

--- a/cromulent/model.py
+++ b/cromulent/model.py
@@ -630,7 +630,8 @@ class BaseResource(ExternalResource):
 		elif type(current) is list:
 			# check value not in list
 			if self._factory.multiple_instances_per_property == "error" and isinstance(value, BaseResource) and value in current:
-				raise DataError("Cannot add the same resource in the same property more than once")
+				raise DataError("""Cannot add the same resource in the same property more than once:
+change factory.multiple_instances_per_property to 'drop' or 'allow'""")
 			current.append(value)
 		else:
 			if self._factory.validate_multiplicity and not multiple:

--- a/cromulent/model.py
+++ b/cromulent/model.py
@@ -751,10 +751,10 @@ change factory.multiple_instances_per_property to 'drop' or 'allow'""")
 					uniq = []
 					for ni in v:
 						if self._factory.multiple_instances_per_property == "drop":
-							if ni in uniq:
+							if id(ni) in uniq:
 								continue
 							else:
-								uniq.append(ni)
+								uniq.append(id(ni))
 						if isinstance(ni, ExternalResource):
 							if done[id(ni)] == id(self):
 								del done[id(ni)]

--- a/cromulent/model.py
+++ b/cromulent/model.py
@@ -82,6 +82,7 @@ class CromulentFactory(object):
 		self.validate_multiplicity = True  # Raise if attempt to set n:1 to []
 		self.auto_assign_id = True # Automatially assign a URI
 		self.process_multiplicity = True # Return multiple with single value as [value]
+		self.multiple_instances_per_property = "drop"
 
 		self.auto_id_type = "int-per-segment" #  "int", "int-per-type", "int-per-segment", "uuid"
 		# self.default_lang = lang  # NOT USED
@@ -627,6 +628,9 @@ class BaseResource(ExternalResource):
 		if not current:
 			object.__setattr__(self, which, value)
 		elif type(current) is list:
+			# check value not in list
+			if self._factory.multiple_instances_per_property == "error" and isinstance(value, BaseResource) and value in current:
+				raise DataError("Cannot add the same resource in the same property more than once")
 			current.append(value)
 		else:
 			if self._factory.validate_multiplicity and not multiple:
@@ -743,7 +747,13 @@ class BaseResource(ExternalResource):
 					d[k] = v._toJSON(done=done, top=top)
 				elif type(v) is list:
 					newl = []
+					uniq = []
 					for ni in v:
+						if self._factory.multiple_instances_per_property == "drop":
+							if ni in uniq:
+								continue
+							else:
+								uniq.append(ni)
 						if isinstance(ni, ExternalResource):
 							if done[id(ni)] == id(self):
 								del done[id(ni)]

--- a/cromulent/vocab.py
+++ b/cromulent/vocab.py
@@ -10,7 +10,7 @@ from .model import Identifier, Mark, HumanMadeObject, Type, \
 	Destruction, AttributeAssignment, BaseResource, PhysicalObject, \
 	Acquisition, HumanMadeFeature, VisualItem, Set, Birth, Death, \
 	PropositionalObject, Payment, Creation, Phase, Period, \
-	Production, \
+	Production, Event, \
 	STR_TYPES, factory
 
 # Add classified_as initialization hack for all resources
@@ -514,10 +514,16 @@ def add_attribute_assignment_check():
 def add_linked_art_boundary_check():
 
 	boundary_classes = [x.__name__ for x in [Actor, HumanMadeObject, Person, Group, VisualItem, \
-		Place, Period, LinguisticObject, Phase, Set]]
-	embed_classes = [x.__name__ for x in [Type, Name, Identifier, Dimension, Birth, Creation, \
-		Currency, Death, Destruction, Dissolution, Formation, Language, \
-		Material, MeasurementUnit, MonetaryAmount, Payment, Production, TimeSpan]]
+		Place, Period, LinguisticObject, Phase, Set, Event]]
+	data_embed_classes = [Name, Identifier, Dimension, TimeSpan, MonetaryAmount]
+	type_embed_classes = [Type, Currency, Language, Material, MeasurementUnit]
+	event_embed_classes = [Birth, Creation, Production, Formation, Payment, \
+							Death, Destruction, Dissolution ]
+	all_embed_classes = []
+	all_embed_classes.extend(data_embed_classes)
+	all_embed_classes.extend(type_embed_classes)
+	all_embed_classes.extend(event_embed_classes)
+	embed_classes = [x.__name__ for x in all_embed_classes]
 
 	# Activity, AttributeAssignment, InformationObject, TransferOfCustody, Move
 	# Propositional Object

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -173,7 +173,7 @@ class TestFactorySerialization(unittest.TestCase):
 		p.classified_as = model.Type(ident="http://example.org/Type", label="Test")
 		res1 = model.factory.toString(p, compact=False, collapse=60) # all new lines
 		res2 = model.factory.toString(p, compact=False, collapse=120) # compact list of type
-		print(res1)
+		# print(res1)
 		self.assertEqual(len(res1.splitlines()), 12)
 		self.assertEqual(len(res2.splitlines()), 6)
 
@@ -462,6 +462,27 @@ class TestMagicMethods(unittest.TestCase):
 		model.factory.validate_multiplicity = False
 		who.born = b2
 		self.assertEqual(who.born, [b1, b2])
+
+	def test_not_multiple_instance(self):
+		who = model.Person()
+		n = model.Name(content="Test")
+		who.identified_by = n
+
+		model.factory.multiple_instances_per_property = "error"
+		self.assertRaises(model.DataError, who.__setattr__, 'identified_by', n)
+		self.assertEqual(who.identified_by, [n])
+
+		model.factory.multiple_instances_per_property = "drop"
+		who.identified_by = n
+		self.assertEqual(who.identified_by, [n,n])		
+		# and check that only serialized once
+		js = model.factory.toJSON(who)
+		self.assertEqual(len(js['identified_by']), 1)
+
+		model.factory.multiple_instances_per_property = "allow"
+		js = model.factory.toJSON(who)
+		self.assertEqual(len(js['identified_by']), 2)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION

Allow `multiple_instances_per_property` setting that governs what to do with a property that has exactly the same resource added to it multiple times.
Split the class list for linked_art_boundary check into different types, as precursor to exposing them to other functions (e.g. merge code)