### PR TITLE
Performance improvements in .extract.extract_monetary_amount

### DIFF
--- a/cromulent/extract.py
+++ b/cromulent/extract.py
@@ -350,14 +350,20 @@ def extract_monetary_amount(data):
 		- bibliographic statement: `price_citation`
 	'''
 	amount_type = 'Price'
-	if 'est_price' in data:
+	if 'price' in data or 'price_amount' in data:
+		amnt = model.MonetaryAmount()
+		price_amount = data.get('price_amount', data.get('price'))
+		price_currency = data.get('price_currency', data.get('price_curr'))
+		note = data.get('price_note', data.get('price_desc'))
+		cite = data.get('price_citation')
+	elif 'est_price' in data or 'est_price_amount' in data:
 		amnt = vocab.EstimatedPrice()
 		price_amount = data.get('est_price_amount', data.get('est_price'))
 		price_currency = data.get('est_price_currency', data.get('est_price_curr'))
 		amount_type = 'Estimated Price'
 		note = data.get('est_price_note', data.get('est_price_desc'))
 		cite = data.get('est_price_citation')
-	elif 'start_price' in data:
+	elif 'start_price' in data or 'start_price_amount' in data:
 		amnt = vocab.StartingPrice()
 		price_amount = data.get('start_price_amount', data.get('start_price'))
 		price_currency = data.get('start_price_currency', data.get('start_price_curr'))
@@ -365,11 +371,7 @@ def extract_monetary_amount(data):
 		note = data.get('start_price_note', data.get('start_price_desc'))
 		cite = data.get('start_price_citation')
 	else:
-		amnt = model.MonetaryAmount()
-		price_amount = data.get('price_amount', data.get('price'))
-		price_currency = data.get('price_currency', data.get('price_curr'))
-		note = data.get('price_note', data.get('price_desc'))
-		cite = data.get('price_citation')
+		return None
 
 	if price_amount or price_currency:
 		if cite:


### PR DESCRIPTION
Prioritize common case, and return early if extraction fails.

This should noticeably help the performance of the sales pipeline which has a lot of price columns.