### PR TITLE
French units

### DIFF
--- a/cromulent/vocab.py
+++ b/cromulent/vocab.py
@@ -295,6 +295,9 @@ identity_instances = {
 
 	"synthetic": {"parent": Type, "id": "xxx", "label": "Synthetic Material"},
 
+	"lignes": {"parent": MeasurementUnit, "id": "300435501", "label": "Paris lines"},
+	"fr_inches": {"parent": MeasurementUnit, "id": "300435502", "label": "Paris inches"},
+	"fr_feet": {"parent": MeasurementUnit, "id":"300435503", "label": "Paris feet"},
 	"inches": {"parent": MeasurementUnit, "id": "300379100", "label": "inches"},
 	"feet": {"parent": MeasurementUnit, "id":"300379101", "label": "feet"},
 	"cm": {"parent": MeasurementUnit, "id": "300379098", "label": "centimeters"},

--- a/tests/test_dimensions.py
+++ b/tests/test_dimensions.py
@@ -3,7 +3,7 @@
 import unittest
 import pprint
 from datetime import datetime
-from cromulent.extract import Dimension
+from cromulent.extract import Dimension, normalized_dimension_object
 import cromulent.extract
 
 class TestDateCleaners(unittest.TestCase):
@@ -37,13 +37,13 @@ class TestDateCleaners(unittest.TestCase):
 			'2 d': [Dimension('2', 'inches', None)],
 			'''2'8"''': [Dimension('2', 'feet', None), Dimension('8', 'inches', None)],
 			'4cm': [Dimension('4', 'cm', None)],
-			'2 pieds 3 pouces': [Dimension('2', 'feet', None), Dimension('3', 'inches', None)],
-			'1 pied 7 pouces': [Dimension('1', 'feet', None), Dimension('7', 'inches', None)],
-			'8 pouce': [Dimension('8', 'inches', None)],
-			'8 pouces': [Dimension('8', 'inches', None)],
-			'8 1/2 pouces': [Dimension('8.5', 'inches', None)],
-			'8 1/4 pouces': [Dimension('8.25', 'inches', None)],
-			'8 1/8 pouces': [Dimension('8.125', 'inches', None)],
+			'2 pieds 3 pouces': [Dimension('2', 'fr_feet', None), Dimension('3', 'fr_inches', None)],
+			'1 pied 7 pouces': [Dimension('1', 'fr_feet', None), Dimension('7', 'fr_inches', None)],
+			'8 pouce': [Dimension('8', 'fr_inches', None)],
+			'8 pouces': [Dimension('8', 'fr_inches', None)],
+			'8 1/2 pouces': [Dimension('8.5', 'fr_inches', None)],
+			'8 1/4 pouces': [Dimension('8.25', 'fr_inches', None)],
+			'8 1/8 pouces': [Dimension('8.125', 'fr_inches', None)],
 			'1': [Dimension('1', None, None)],
 		}
 
@@ -65,17 +65,17 @@ class TestDateCleaners(unittest.TestCase):
 			'''2'2"h x 2'8"w''': ([Dimension('2', 'feet', 'height'), Dimension('2', 'inches', 'height')], [Dimension('2', 'feet', 'width'), Dimension('8', 'inches', 'width')]),
 			'''1'3"x4cm h''': ([Dimension('1', 'feet', None), Dimension('3', 'inches', None)], [Dimension('4', 'cm', 'height')]),
 			'''1'3" by 4"''': ([Dimension('1', 'feet', None), Dimension('3', 'inches', None)], [Dimension('4', 'inches', None)]),
-			'Haut 14 pouces, large 10 pouces': ([Dimension('14', 'inches', 'height')], [Dimension('10', 'inches', 'width')]),
-			'Haut. 48 pouces, large 68 pouces': ([Dimension('48', 'inches', 'height')], [Dimension('68', 'inches', 'width')]),
+			'Haut 14 pouces, large 10 pouces': ([Dimension('14', 'fr_inches', 'height')], [Dimension('10', 'fr_inches', 'width')]),
+			'Haut. 48 pouces, large 68 pouces': ([Dimension('48', 'fr_inches', 'height')], [Dimension('68', 'fr_inches', 'width')]),
 			'1 by 4': ([Dimension('1', None, None)], [Dimension('4', None, None)]),
 			'Hoog. 6 v., breed 3 v': ([Dimension('6', 'feet', 'height')], [Dimension('3', 'feet', 'width')]),
 			'Breedt 6 v., hoog 3 v': ([Dimension('6', 'feet', 'width')], [Dimension('3', 'feet', 'height')]),
 			'20 cm x 24,5 cm': ([Dimension('20', 'cm', None)], [Dimension('24.5', 'cm', None)]),
 			'2 w by 5 h': ([Dimension('2', None, 'width')], [Dimension('5', None, 'height')]),
-			'Hauteur 1 pied 4 pouces, largeur 1 pied 1/2 pouc.': ([Dimension('1', 'feet', 'height'), Dimension(value='4', unit='inches', which='height')], [Dimension('1', 'feet', 'width'), Dimension(value='0.5', unit='inches', which='width')]),
-			'h.73 pouces 4 lignes, l.50 pouces': ([Dimension(value='73', unit='inches', which='height'), Dimension(value='4', unit='ligne', which='height')], [Dimension(value='50', unit='inches', which='width')]),
-			'haut. 5 pouc. larg. 5 pouc. 4 linges': ([Dimension(value='5', unit='inches', which='height')], [Dimension(value='5', unit='inches', which='width'), Dimension(value='4', unit='ligne', which='width')]),
-			'haut. 9 pouc. 4 lignes larg. 10 pouc. 4 linges': ([Dimension(value='9', unit='inches', which='height'), Dimension(value='4', unit='ligne', which='height')], [Dimension(value='10', unit='inches', which='width'), Dimension(value='4', unit='ligne', which='width')])
+			'Hauteur 1 pied 4 pouces, largeur 1 pied 1/2 pouc.': ([Dimension('1', 'fr_feet', 'height'), Dimension(value='4', unit='fr_inches', which='height')], [Dimension('1', 'fr_feet', 'width'), Dimension(value='0.5', unit='fr_inches', which='width')]),
+			'h.73 pouces 4 lignes, l.50 pouces': ([Dimension(value='73', unit='fr_inches', which='height'), Dimension(value='4', unit='ligne', which='height')], [Dimension(value='50', unit='fr_inches', which='width')]),
+			'haut. 5 pouc. larg. 5 pouc. 4 linges': ([Dimension(value='5', unit='fr_inches', which='height')], [Dimension(value='5', unit='fr_inches', which='width'), Dimension(value='4', unit='ligne', which='width')]),
+			'haut. 9 pouc. 4 lignes larg. 10 pouc. 4 linges': ([Dimension(value='9', unit='fr_inches', which='height'), Dimension(value='4', unit='ligne', which='height')], [Dimension(value='10', unit='fr_inches', which='width'), Dimension(value='4', unit='ligne', which='width')])
 		}
 
 		for value, expected in tests.items():
@@ -90,6 +90,22 @@ class TestDateCleaners(unittest.TestCase):
 				self.assertEqual(dims, expected, msg='dimensions: %r' % (value,))
 			else:
 				self.assertIsNone(dims)
+
+	def test_normalize_dimension(self):
+		tests = {
+			'1 ft, 2 in': ('1 foot, 2 inches', Dimension(value='14.0', unit='inches', which=None)),
+			'8 1/2 pouces': ('8.5 French inches', Dimension(value='8.5', unit='fr_inches', which=None)),
+			'1 pied 7 pouces': ('1 French foot, 7 French inches', Dimension(value='19.0', unit='fr_inches', which=None)),
+			'2 pied 1/2 pouces': ('2 French feet, 0.5 French inches', Dimension(value='24.5', unit='fr_inches', which=None)),
+			'1 pied 3 pouce. 3 linges': ('1 French foot, 3 French inches, 3 lignes', Dimension(value='15.25', unit='fr_inches', which=None)),
+		}
+		for value, expected in tests.items():
+			elabel, edim = expected
+			dims = cromulent.extract.parse_simple_dimensions(value)
+			dim, label = normalized_dimension_object(dims)
+			self.assertEqual(label, elabel)
+			self.assertEqual(dim, edim)
+
 
 if __name__ == '__main__':
 	unittest.main()

--- a/tests/test_dimensions.py
+++ b/tests/test_dimensions.py
@@ -73,6 +73,9 @@ class TestDateCleaners(unittest.TestCase):
 			'20 cm x 24,5 cm': ([Dimension('20', 'cm', None)], [Dimension('24.5', 'cm', None)]),
 			'2 w by 5 h': ([Dimension('2', None, 'width')], [Dimension('5', None, 'height')]),
 			'Hauteur 1 pied 4 pouces, largeur 1 pied 1/2 pouc.': ([Dimension('1', 'feet', 'height'), Dimension(value='4', unit='inches', which='height')], [Dimension('1', 'feet', 'width'), Dimension(value='0.5', unit='inches', which='width')]),
+			'h.73 pouces 4 lignes, l.50 pouces': ([Dimension(value='73', unit='inches', which='height'), Dimension(value='4', unit='ligne', which='height')], [Dimension(value='50', unit='inches', which='width')]),
+			'haut. 5 pouc. larg. 5 pouc. 4 linges': ([Dimension(value='5', unit='inches', which='height')], [Dimension(value='5', unit='inches', which='width'), Dimension(value='4', unit='ligne', which='width')]),
+			'haut. 9 pouc. 4 lignes larg. 10 pouc. 4 linges': ([Dimension(value='9', unit='inches', which='height'), Dimension(value='4', unit='ligne', which='height')], [Dimension(value='10', unit='inches', which='width'), Dimension(value='4', unit='ligne', which='width')])
 		}
 
 		for value, expected in tests.items():


### PR DESCRIPTION
This does two things:

* Differentiates French and imperial feet and inches (previously these were treated the same)
* Adds support for French `lignes`

When/if `cromulent.vocab.instances` gains a `fr_inches` entry, results from `cromulent.extract.extract_physical_dimensions` on data using French units should automatically gain unit assertions.