### PR TITLE
Add vocab._BriefText.

### DIFF
--- a/cromulent/vocab.py
+++ b/cromulent/vocab.py
@@ -82,6 +82,7 @@ ext_classes = {
 	"Markings": {"parent": LinguisticObject, "id": "300028744", "label": "Markings", "brief": True},
 	"Watermarks": {"parent": LinguisticObject, "id": "300028749", "label": "Watermarks", "brief": True},
 
+	"_BriefText": {"parent": LinguisticObject, "id": "300418049", "label":"Brief Text"},
 	"MaterialStatement": {"parent": LinguisticObject, "id": "300010358", "label": "Material Statement", "brief": True},
 	"DimensionStatement": {"parent": LinguisticObject, "id": "300266036", "label": "Dimension Statement", "brief": True},
 	"CreditStatement": {"parent": LinguisticObject, "id": "300026687", "label": "Credit Statement", "brief": True},


### PR DESCRIPTION
This is not meant to be instantiated directly, but is useful for code in [pipeline](http://github.com/thegetty/pipeline) that tests if an object is classified as `BriefText`.