### PR TITLE
Assigned prop vocab

### DIFF
--- a/cromulent/data/linked-art.json
+++ b/cromulent/data/linked-art.json
@@ -2380,7 +2380,7 @@
     }, 
     "assigned_property": {
       "@id": "crm:P177_assigned_property_type", 
-      "@type": "@id"
+      "@type": "@vocab"
     }, 
     "sales_price": {
       "@id": "crm:P179_had_sales_price", 

--- a/cromulent/vocab.py
+++ b/cromulent/vocab.py
@@ -457,6 +457,7 @@ identity_instances = {
 	"public collection": {"parent": Type, "id": "300411912", "label": "Public Collection"},
 	"computer generated": {"parent": Type, "id": "300202389", "label": "Computer Generated"},
 	"vandalism": {"parent": Type, "id":"300055299", "label": "Vandalism"},
+	"contribution": {"parent": Type, "id":"300403975", "label":"Contribution"},  # As opposed to primarily responsible
 
 	# Subjects -- use is_about / subject project, no need to metatype
 	"gender issues": {"parent": Type, "id": "300233686", "label": "Gender Issues"},
@@ -614,10 +615,7 @@ def add_attribute_assignment_check():
 	def aa_set_assigned_property_type(self, value):
 		ass_res = getattr(self, ass, None)
 		assto_res = getattr(self, assto, None)
-		if not assto_res:
-			# override
-			assto_res = BaseResource()
-		if ass_res:
+		if ass_res and assto_res:
 			assto_res._check_prop(value, ass_res)
 		object.__setattr__(self, p177, value)
 	setattr(AttributeAssignment, "set_%s" % p177, aa_set_assigned_property_type)

--- a/utils/make_jsonld_context.py
+++ b/utils/make_jsonld_context.py
@@ -38,7 +38,7 @@ extension = OrderedDict()
 extension['@version'] = 1.1
 extension['crm'] = "http://www.cidoc-crm.org/cidoc-crm/"
 
-vocab_properties = ["assigned_property_type"]
+vocab_properties = ["assigned_property"]
 
 parts = {
 	"P9": ["crm:P9_consists_of", "crm:P9i_forms_part_of"],


### PR DESCRIPTION

* Make `assigned_property` `@type: @vocab` so it picks up the context (typo in the field in the builder)
* Make `assigned_property` only test when the subject of the triple is valid
* Add a "contribution" aat entry for examples of Production/Creation part classifications