### PR TITLE
add more provenance terms

### DIFF
--- a/cromulent/vocab.py
+++ b/cromulent/vocab.py
@@ -653,7 +653,7 @@ def add_linked_art_boundary_check():
 					return True
 		# Non Statement Linguistic objects might still be internal or external
 		# so apply logic from relating properties, not return False
-		elif isinstance(value, Procurement):
+		elif isinstance(value, ProvenanceEntry):
 			return False
 
 		if rel in ["part", "member"]:

--- a/cromulent/vocab.py
+++ b/cromulent/vocab.py
@@ -209,23 +209,25 @@ ext_classes = {
 	"Hiring":      {"parent": Activity, "id":"300109703", "label": "Hiring"},
 
 	"Purchase":  {"parent":Acquisition, "id":"300077989", "label": "Purchasing"},
-	"Procurement": {"parent": Activity, "id":"300137616", "label": "Procurement"},
 	"Assembling": {"parent": Activity, "id":"300077121", "label":"Assembling"},
 	"Managing": {"parent": Activity, "id":"300054277", "label": "Managing"},
 	"Storing": {"parent": Activity, "id":"300056390", "label": "Storing"},
 	"Producing": {"parent": Activity, "id":"300054713", "label": "Producing"},
+
+	"ProvenanceEntry": {"parent": Activity, "id":"300055863", "label": "Provenance Entry"},
+	"ReturnOfLoan": {"parent": TransferOfCustody, "id":"300438467", "label": "Return of Loan"},
+	"Theft": {"parent": TransferOfCustody, "id": "300055292", "label": "Theft"},
+	"Looting": {"parent": TransferOfCustody, "id":"300379554", "label": "Looting"},
+	"Loss": {"parent": TransferOfCustody, "id":"300417655", "label": "Loss"},
+	"Loan": {"parent": TransferOfCustody, "id":"300417645", "label": "Loan"},
+	"LongtermLoan": {"parent": TransferOfCustody, "id":"300417646", "label": "Long-term Loan"},
+	"SaleOfStolenGoods": {"parent": TransferOfCustody, "id":"xxx", "label":"Sale of Stolen Goods"},
 
 	"PossibleAssignment": {"parent": AttributeAssignment, "id":"300435722", "label": "Possibly"}, 
 	"ProbableAssignment": {"parent": AttributeAssignment, "id":"300435721", "label": "Probably"},
 	"ObsoleteAssignment": {"parent": AttributeAssignment, "id":"300404908", "label": "Obsolete"},
 
 	"ExhibitionIdea": {"parent": PropositionalObject, "id":"300417531", "label": "Exhibition"},
-
-	"Theft": {"parent": TransferOfCustody, "id": "300055292", "label": "Theft"},
-	"Looting": {"parent": TransferOfCustody, "id":"300379554", "label": "Looting"},
-	"Loss": {"parent": TransferOfCustody, "id":"300417655", "label": "Loss"},
-	"Loan": {"parent": TransferOfCustody, "id":"300417645", "label": "Loan"},
-	"LongtermLoan": {"parent": TransferOfCustody, "id":"300417646", "label": "Long-term Loan"},
 
 	"AuctionLotSet": {"parent": Set, "id":"300411307", "label": "Auction Lot"},
 	"CollectionSet": {"parent": Set, "id":"300025976", "label": "Collection"},

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -99,7 +99,7 @@ class TestClassBuilder(unittest.TestCase):
 	def test_procurement_boundary(self):
 		vocab.add_linked_art_boundary_check()
 		a = model.Activity()
-		p = vocab.Procurement()
+		p = vocab.ProvenanceEntry()
 		a.caused = p
 		js = factory.toJSON(a)
 		self.assertTrue(not 'classified_as' in js['caused'][0])		


### PR DESCRIPTION

@kasei Note well that this renames `Procurement` to `ProvenanceEntry`.  Saying that losing an object was a procurement was too galling!

Also adds terms from Patricia, and placeholder for sale of stolen goods.