### PR TITLE
Improve reader, fix some tests

### DIFF
--- a/cromulent/vocab.py
+++ b/cromulent/vocab.py
@@ -582,7 +582,7 @@ def conceptual_only_parts():
 		elif what == "part_of":
 			return self.c_part_of
 		else:
-			getattr(self, what)
+			object.__getattr__(self, what)
 
 	Right.set_part = set_c_part
 	Right.set_part_of = set_c_part_of

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -11,6 +11,8 @@ from cromulent import reader
 from cromulent.model import factory, Person, DataError, BaseResource, \
 	Dimension, override_okay
 
+from cromulent import vocab
+
 class TestReader(unittest.TestCase):
 
 	def setUp(self):
@@ -41,3 +43,27 @@ class TestReader(unittest.TestCase):
 
 		unknown2 = '{"type":"Person", "fishbat": "bob"}'
 		self.assertRaises(DataError, self.reader.read, unknown)
+
+	def test_attrib_assign(self):
+		vocab.add_attribute_assignment_check()
+
+		data = """
+		{
+		  "id": "https://linked.art/example/activity/12", 
+		  "type": "AttributeAssignment", 
+		  "assigned": {
+		    "id": "https://linked.art/example/name/10", 
+			"type": "Name", 
+		    "content": "Exhibition Specific Name"
+		  }, 
+		  "assigned_property": "identified_by", 
+		  "assigned_to": {
+		    "id": "https://linked.art/example/object/12", 
+		    "type": "HumanMadeObject", 
+		    "_label": "Real Painting Name"
+		  }
+		}
+		"""
+		d = self.reader.read(data)
+		
+

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -9,7 +9,7 @@ except:
 
 from cromulent import reader
 from cromulent.model import factory, Person, DataError, BaseResource, \
-	Dimension, override_okay
+	Dimension, override_okay, AttributeAssignment
 
 from cromulent import vocab
 
@@ -65,5 +65,7 @@ class TestReader(unittest.TestCase):
 		}
 		"""
 		d = self.reader.read(data)
-		
+		self.assertTrue(isinstance(d, AttributeAssignment))
+
+
 

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -43,6 +43,21 @@ class TestClassBuilder(unittest.TestCase):
 		self.assertTrue(len(inst.classified_as) == 1)
 		self.assertTrue(inst.classified_as[0].id == "http://vocab.getty.edu/aat/300033618")
 
+	def test_conceptual_parts(self):
+		r = model.Right()
+		r2 = model.Right()
+		self.assertRaises(model.DataError, r.__setattr__, 'part', r2)
+		r.c_part = r2
+		self.assertTrue(r2 in r.c_part)
+
+		vocab.conceptual_only_parts()
+		r3 = model.Right()
+		r4 = model.Right()
+		r3.part = r4
+		self.assertTrue(r4 in r3.c_part)
+		self.assertTrue("part" in model.factory.toJSON(r3))
+		self.assertTrue(r4 in r3.part)
+
 
 	def test_art_setter(self):
 		p = model.HumanMadeObject("a", art=1)
@@ -54,6 +69,13 @@ class TestClassBuilder(unittest.TestCase):
 		p2j = p2._toJSON(done={})
 
 	def test_aa_check(self):
+
+		# Make sure that some other test hasn't set it
+		try:
+			del model.AttributeAssignment.set_assigned_property
+		except:
+			pass
+
 		t = model.Type()
 		aa = model.AttributeAssignment()
 		# First check that aa accepts a type


### PR DESCRIPTION

Reader now  works with add_attribute_assignment and conceptual parts.
Also creates instances of vocab "extension" classes,  rather than vanilla classes  from the  model with the right classifications.
This is important for boundary checking, in case the test looks for the vocab class, rather than the classification.

Also fix some edge cases revealed by testing the reader on all the examples in linked art site, and add tests.