### PR TITLE
Performance improvements

### DIFF
--- a/cromulent/model.py
+++ b/cromulent/model.py
@@ -942,11 +942,12 @@ change factory.multiple_instances_per_property to 'drop' or 'allow'""")
 		if top is self and not id(self) in done and self._factory.context_uri: 
 			result['@context'] = self._factory.context_uri
 
-		result['id'] = self.id
+		if self.id:
+			result['id'] = self.id
 		if self.type:
 			result['type'] = self.type
 		try:
-			result['_label'] = d['_label']
+			result['_label'] = self._label
 		except:
 			pass
 
@@ -1047,6 +1048,7 @@ change factory.multiple_instances_per_property to 'drop' or 'allow'""")
 		if top is self and not id(self) in done and self._factory.context_uri: 
 			result['@context'] = self._factory.context_uri
 
+
 		result['id'] = self.id
 		result['type'] = self.type
 		try:
@@ -1087,10 +1089,12 @@ change factory.multiple_instances_per_property to 'drop' or 'allow'""")
 				result[k] = v._toJSON_faster(done=done, top=top)
 			elif type(v) is list:
 				newl = []
-				if isinstance(ni, ExternalResource):
-					if done[id(ni)] == id(self):
-						del done[id(ni)]
-					newl.append(ni._toJSON_fast(done=done, top=top))
+				for nv in v:
+					if isinstance(nv, ExternalResource):
+						if self._factory.linked_art_boundaries and \
+							not self._linked_art_boundary_okay(top, k, nv):
+							done[id(nv)] = 1
+					newl.append(ni._toJSON_faster(done=done, top=top))
 				else:
 					# A number or string
 					newl.append(ni)

--- a/cromulent/model.py
+++ b/cromulent/model.py
@@ -434,14 +434,22 @@ class CromulentFactory(object):
 		fh.close()
 		return out
 
-	def production_mode(self):
-		self.cache_hierarchy()
-		self.validate_profile = False
-		self.validate_properties = False
-		self.validate_range = False
-		self.validate_multiplicity = False
-		return True
-
+	def production_mode(self, state="on"):
+		if state == "on":
+			self.cache_hierarchy()
+			self.validate_profile = False
+			self.validate_properties = False
+			self.validate_range = False
+			self.validate_multiplicity = False
+			return True
+		else:
+			self.validate_profile = True
+			self.validate_properties = True
+			self.validate_range = True
+			self.validate_multiplicity = True
+			# no way to undo the hierarchy cache
+			return False
+			
 	def cache_hierarchy(self):
 		""" For each class, walk up the hierarchy and cache the terms """
 		# This will work with the existing code, as it will find it in the first
@@ -529,10 +537,6 @@ class BaseResource(ExternalResource):
 		"""Initialize BaseObject."""
 		super(BaseResource, self).__init__(ident)
 
-		# Alias value and content together
-		if content and not value:
-			value = content
-
 		if self._factory.validate_profile and hasattr(self, '_okayToUse'): 
 			if not self._okayToUse:
 				raise ProfileError("Class '%s' is configured to not be used" % self.__class__._type)
@@ -544,14 +548,18 @@ class BaseResource(ExternalResource):
 			self._label = label
 		# this might raise an exception if value is not allowed on the object
 		# but easier to do it in the main init than on many generated subclasses
-		if value:
-			try:
-				self.value = value
-			except:
-				try:
-					self.content = value
-				except:
-					raise ProfileError("Class '%s' does not hold values" % self.__class__._type)
+
+		is_sym = isinstance(self, SymbolicObject)
+		is_dim = isinstance(self, Dimension)
+
+		if value and is_dim:
+			self.value = value
+		elif content and is_sym:
+			self.content = content
+		elif value and is_sym:
+			self.content = value
+		elif value or content:
+			raise ProfileError("Class '%s' does not hold values" % self.__class__._type)
 		# Custom post initialization function for autoconstructed classes
 		self._post_init(**kw)
 
@@ -745,9 +753,10 @@ change factory.multiple_instances_per_property to 'drop' or 'allow'""")
 			del d['context']
 
 		# Check mandatory properties
-		for e in self._required_properties:
-			if e not in d:
-				raise RequirementError("Resource type '%s' requires '%s' to be set" % (self._type, e), self)
+		if self._factory.validate_profile:
+			for e in self._required_properties:
+				if e not in d:
+					raise RequirementError("Resource type '%s' requires '%s' to be set" % (self._type, e), self)
 
 		debug = self._factory.debug_level
 		if debug.find("warn") > -1:
@@ -912,6 +921,117 @@ change factory.multiple_instances_per_property to 'drop' or 'allow'""")
 			return OrderedDict(sorted(d.items(), key=lambda x: KOH.get(x[0], 1000)))
 		else:
 			return d
+
+
+
+	def _toJSON_fast(self, done, top=None):
+		"""Serialize as JSON."""
+		# If we're already in the graph, return our URI only
+		# This should only be called from the factory!
+
+		# id, type, _label is the default.
+		if not self._factory.id_type_label and id(self) in done:
+			return self.id
+
+		# Can't pass in self as a param
+		if top is None:
+			top = self
+
+		# Add back context at the top, if set
+		result = {}
+		if top is self and not id(self) in done and self._factory.context_uri: 
+			result['@context'] = self._factory.context_uri
+
+		result['id'] = self.id
+		if self.type:
+			result['type'] = self.type
+
+		# Need only minimal representation of self
+		if (self._factory.id_type_label and id(self) in done) or (top is not self and not self._embed):
+			# limit to only id, type, label
+			try:
+				result['_label'] = d['_label']
+			except:
+				pass
+			return result
+		else:	
+			# otherwise, we're about to serialize the resource completely
+			done[id(self)] = 1			
+
+		d = self.__dict__.copy()
+		del d['_factory']
+		del d['id']
+
+		# Need to do in order now to get done correctly ordered
+		if self._factory.order_json:
+			KOH = self._factory.key_order_hash
+			kodflt = self._factory.key_order_default
+			kvs = sorted(d.items(), key=lambda x: KOH.get(x[0], kodflt))
+		else:
+			kvs = list(d.items())
+
+		tbd = []
+		for (k, v) in kvs:
+			if not v or (k[0] == "_" and not k in self._factory.underscore_properties):
+				del d[k]
+			else:
+				# Should we do this at all? Could be outside of our API serialization scope
+				if isinstance(v, ExternalResource):
+					if self._factory.linked_art_boundaries and \
+						not self._linked_art_boundary_okay(top, k, v):
+						# never follow, so just add to done
+						done[id(v)] = 1
+					else:
+						tbd.append(id(v))
+				elif type(v) is list:
+					for ni in v:
+						if isinstance(ni, ExternalResource):
+							if self._factory.linked_art_boundaries and \
+								not self._linked_art_boundary_okay(top, k, ni):
+								# never follow, so just add to done
+								done[id(ni)] = 1							
+							else:
+								tbd.append(id(ni))
+					# For completeness should check list-of-datetime here too
+				elif isinstance(v, datetime.datetime):
+					# replace with string
+					kvs[k] = v.strftime("%Y-%m-%dT%H:%M:%SZ")
+				# else
+				# this is likely a literal value, 
+				# otherwise it's going to die in upstream serialization anyway
+
+		for t in tbd:
+			if not t in done:
+				done[t] = id(self)
+			
+		# This is already sorted if needed
+		for (k,v) in kvs:
+			if v and (k[0] != "_" and not k in self._factory.underscore_properties):
+				if isinstance(v, ExternalResource):
+					if done[id(v)] == id(self):
+						del done[id(v)]
+					result[k] = v._toJSON_fast(done=done, top=top)
+				elif type(v) is list:
+					newl = []
+					uniq = set()
+					for ni in v:
+						if self._factory.multiple_instances_per_property == "drop":
+							if id(ni) in uniq:
+								continue
+							else:
+								uniq.add(id(ni))
+						if isinstance(ni, ExternalResource):
+							if done[id(ni)] == id(self):
+								del done[id(ni)]
+							newl.append(ni._toJSON_fast(done=done, top=top))
+						else:
+							# A number or string
+							newl.append(ni)
+					result[k] = newl
+				else:
+					result[k] = v
+		return result
+
 
 	def _linked_art_boundary_okay(self, top, prop, value):
 		# Return false to say do not cross this boundary

--- a/cromulent/model.py
+++ b/cromulent/model.py
@@ -982,6 +982,7 @@ change factory.multiple_instances_per_property to 'drop' or 'allow'""")
 
 		tbd = []
 		for (k, v) in kvs:
+			k = self._property_name_map.get(k, k)
 			if isinstance(v, ExternalResource):
 				if self._factory.linked_art_boundaries and \
 					not self._linked_art_boundary_okay(top, k, v):
@@ -1009,6 +1010,7 @@ change factory.multiple_instances_per_property to 'drop' or 'allow'""")
 			
 		# This is already sorted if needed
 		for (k,v) in kvs:
+			k = self._property_name_map.get(k, k)
 			if not v:
 				pass
 			elif isinstance(v, ExternalResource):

--- a/cromulent/model.py
+++ b/cromulent/model.py
@@ -988,8 +988,12 @@ change factory.multiple_instances_per_property to 'drop' or 'allow'""")
 			kvs.sort(key=lambda x: KOH.setdefault(x[0], kodflt))
 			
 		# tbd vs done is to ensure that in a DAG rather than a tree
-		# that it is serialized breadth first per level of the graph, 
-		# not depth first. This doesn't catch the pattern A-B-C-D / A-E-D,
+		# that children of the current node are given priority for
+		# full serialization, rather than deeper descendent nodes
+		# that would otherwise be processed first during the (recursive)
+		# depth-first traversal.
+
+		# This doesn't catch the pattern A-B-C-D / A-E-D,
 		# (D will be under B-C, not under E) as B is processed completely
 		# before E.
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -93,10 +93,9 @@ class TestFactorySerialization(unittest.TestCase):
 		model.factory.json_serializer = "normal"
 
 	def test_toJSON_normal(self):
-		expect = OrderedDict([(u'@context', 'http://lod.getty.edu/context.json'), 
+		expect = OrderedDict([(u'@context', model.factory.context_uri), 
 			(u'@id', u'http://lod.example.org/museum/Person/1'), (u'@type', u'crm:E21_Person'),
 			('rdfs:label', 'Test Person')])
-		model.factory.context_uri = 'http://lod.getty.edu/context.json'
 		model.factory.full_names = True
 		p = model.Person("1")
 		p._label = "Test Person"
@@ -104,19 +103,22 @@ class TestFactorySerialization(unittest.TestCase):
 		self.assertEqual(expect, outj)
 		# reset
 		model.factory.full_names = False
-		model.factory.context_uri = ""
 
 	def test_toString(self):
-		expect = u'{"id":"http://lod.example.org/museum/InformationObject/collection","type":"InformationObject","_label":"Test Object"}'
+		expect = u'{"@context":"'+model.factory.context_uri+'","id":"http://lod.example.org/museum/InformationObject/collection","type":"InformationObject","_label":"Test Object"}'
 		outs = model.factory.toString(self.collection)
 		self.assertEqual(expect, outs)
 
 	def test_toString_fast(self):
-		expect = u'{"id":"http://lod.example.org/museum/InformationObject/collection","type":"InformationObject","_label":"Test Object"}'
-		model.factory.json_serializer = "fast"		
-		outs = model.factory.toString(self.collection)
-		model.factory.json_serializer = "normal"
-		self.assertEqual(expect, outs)
+		# Should only be trusted in python 3
+		if sys.version_info.major >= 3 and sys.version_info.minor >= 6:
+			expect = u'{"@context":"'+model.factory.context_uri+'","id":"http://lod.example.org/museum/InformationObject/collection","type":"InformationObject","_label":"Test Object"}'
+			model.factory.json_serializer = "fast"		
+			outs = model.factory.toString(self.collection)
+			model.factory.json_serializer = "normal"
+			self.assertEqual(expect, outs)
+		else:
+			print("Skipping toString_fast test in Python 2.x")
 
 	def test_toFile(self):
 		self.assertRaises(model.ConfigurationError, model.factory.toFile, self.collection)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -213,9 +213,7 @@ class TestFactorySerialization(unittest.TestCase):
 		p.part = model.HumanMadeObject()
 		js = model.factory.toJSON(p)
 
-		model.factory.production_mode(state="off")
-
-
+		model.factory.production_mode(state=False)
 
 
 


### PR DESCRIPTION

Add a Python3 only serializer that relies on 3.7+ dicts being ordered.
Reduces the time to serialize by about 40%.
Need to set factory.json_serializer to "fast" to enable this.

Also:
* fixes some production_mode issues.
* adds a "off" flag to production_mode to reset the flags (but can't un-cache the hierarchy)
* put a test around required properties for validation


